### PR TITLE
LIQUTIL-9: Upgrade to RAML Module Builder 32.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.0.0.CR2</vertx.version>
+    <vertx.version>4.0.0</vertx.version>
     <liquibase.version>3.8.9</liquibase.version>
-    <raml-module-builder.version>32.0.2</raml-module-builder.version>
+    <raml-module-builder.version>32.1.0</raml-module-builder.version>
     <junit.version>4.13.1</junit.version>
   </properties>
 


### PR DESCRIPTION
1. rmb updated to the 32.1.0.
2. Vertx updated to the 4.0.0.