### PR TITLE
LIQUTIL-11 Upgrade to RAML Module Builder 33.2.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 1.3.0 xxxx-xx-xx
+* [LIQUTIL-11](https://issues.folio.org/browse/LIQUTIL-11) Upgrade to RAML Module Builder 33.2.3
+
 ## 1.2.0 2021-02-11
 * [LIQUTIL-9](https://issues.folio.org/browse/LIQUTIL-9) Upgrade to RAML Module Builder 32.x
 * [LIQUTIL-8](https://issues.folio.org/browse/LIQUTIL-8) Add personal data disclosure form

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.0.0</vertx.version>
+    <vertx.version>4.2.2</vertx.version>
     <liquibase.version>3.8.9</liquibase.version>
-    <raml-module-builder.version>32.1.0</raml-module-builder.version>
+    <raml-module-builder.version>33.2.3</raml-module-builder.version>
     <junit.version>4.13.1</junit.version>
   </properties>
 
@@ -52,6 +52,12 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
       <version>${vertx.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>postgres-testing</artifactId>
+      <version>${raml-module-builder.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/folio/liquibase/LiquibaseUtilTest.java
+++ b/src/test/java/org/folio/liquibase/LiquibaseUtilTest.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.persist.PostgresClient;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -34,11 +35,9 @@ public class LiquibaseUtilTest {
 
     Async async = context.async();
 
-    PostgresClient.setIsEmbedded(true);
+    PostgresClient.setPostgresTester(new PostgresTesterContainer());
 
     PostgresClient postgresClient = PostgresClient.getInstance(vertx);
-
-    postgresClient.startEmbeddedPostgres();
 
     postgresClient.select("SELECT 1", context.asyncAssertSuccess());
 
@@ -130,7 +129,7 @@ public class LiquibaseUtilTest {
 
       // close vertx
       vertx.close(context.asyncAssertSuccess(closRes -> {
-        PostgresClient.stopEmbeddedPostgres();
+        PostgresClient.stopPostgresTester();
         async.complete();
       }));
     });

--- a/src/test/java/org/folio/rest/tools/utils/ModuleName.java
+++ b/src/test/java/org/folio/rest/tools/utils/ModuleName.java
@@ -1,0 +1,11 @@
+package org.folio.rest.tools.utils;
+
+public class ModuleName {
+
+  private static final String MODULE_NAME = "folio_liquibase_util";
+
+  public static String getModuleName() {
+    return MODULE_NAME;
+  }
+
+}


### PR DESCRIPTION
ModuleName class is required by Postgres tester container, was added for testing explicitly to avoid adding domain-models-maven-plugin