### PR TITLE
LIQUTIL-17: Pass exceptions, don't catch and swallow them

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <liquibase.version>4.7.1</liquibase.version>
     <raml-module-builder.version>33.2.3</raml-module-builder.version>
     <junit.version>4.13.1</junit.version>
+    <postgresql.version>42.3.2</postgresql.version>
   </properties>
 
   <dependencies>
@@ -42,6 +43,7 @@
       <artifactId>domain-models-runtime</artifactId>
       <version>${raml-module-builder.version}</version>
     </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -58,6 +60,18 @@
       <groupId>org.folio</groupId>
       <artifactId>postgres-testing</artifactId>
       <version>${raml-module-builder.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${postgresql.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
LiquibaseUtil catches exceptions, logs them, but swallows (ignores) them so that the caller assumes that the method succeeded successfully:

https://github.com/folio-org/folio-liquibase-util/blob/v1.3.0/src/main/java/org/folio/liquibase/LiquibaseUtil.java#L46
https://github.com/folio-org/folio-liquibase-util/blob/v1.3.0/src/main/java/org/folio/liquibase/LiquibaseUtil.java#L64

See these reports of silent liquibase fails:

https://issues.folio.org/browse/RMB-895
https://issues.folio.org/browse/MODSOURCE-380
https://issues.folio.org/browse/MODSOURCE-381

LiquibaseUtil should pass on all exceptions. Checked exceptions should be wrapped
as unchecked exceptions to avoid a breaking change of the method declaration.

This PR also fixes runScripts so that liquibase gets closed.