### PR TITLE
LIQUTIL-19: Update dependencies fixing CVE-2020-36518, CVE-2021-43797

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vertx.version>4.2.6</vertx.version>
-    <liquibase.version>4.7.1</liquibase.version>
+    <liquibase.version>4.9.0</liquibase.version>
     <raml-module-builder.version>33.2.8</raml-module-builder.version>
     <junit.version>4.13.1</junit.version>
     <postgresql.version>42.3.3</postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.2.2</vertx.version>
+    <vertx.version>4.2.6</vertx.version>
     <liquibase.version>4.7.1</liquibase.version>
-    <raml-module-builder.version>33.2.3</raml-module-builder.version>
+    <raml-module-builder.version>33.2.8</raml-module-builder.version>
     <junit.version>4.13.1</junit.version>
     <postgresql.version>42.3.3</postgresql.version>
   </properties>


### PR DESCRIPTION
Update liquibase-core from 4.7.1 to 4.9.0 fixing https://nvd.nist.gov/vuln/detail/CVE-2022-0839

Update Vert.x from 4.2.4 to 4.2.6.

Update RMB from 33.2.5 to 33.2.8. This updates jackson-databind from 2.13.1 to 2.13.2.1 fixing https://nvd.nist.gov/vuln/detail/CVE-2020-36518