### PR TITLE
LIQUTIL-21: No suitable driver found for jdbc:postgresql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
       <version>${liquibase.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${postgresql.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
       <version>${raml-module-builder.version}</version>
@@ -66,12 +71,6 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <version>2.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>${postgresql.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION


RMB no longer ships with org.postgresql:postgresql driver because RMB uses the Vert.x Async PostgreSQL driver.

Liquibase doesn't support the Vert.x driver and fails with this error message:

```
15:54:34 [] [] [] [] ERROR LiquibaseUtil        Error while initializing schema for the module
java.sql.SQLException: No suitable driver found for jdbc:postgresql://null:null/postgres
        at java.sql.DriverManager.getConnection(Unknown Source) ~[java.sql:?]
        at java.sql.DriverManager.getConnection(Unknown Source) ~[java.sql:?]
        at org.folio.liquibase.SingleConnectionProvider.getConnectionInternal(SingleConnectionProvider.java:65) ~[mod-pubsub-server-fat.jar:?]
        at org.folio.liquibase.SingleConnectionProvider.getConnection(SingleConnectionProvider.java:55) ~[mod-pubsub-server-fat.jar:?]
        at org.folio.liquibase.LiquibaseUtil.initializeSchemaForModule(LiquibaseUtil.java:41) ~[mod-pubsub-server-fat.jar:?]
```

Therefore folio-liquibase-util needs to ship with the org.postgresql:postgresql driver.