### PR TITLE
LIQUTIL-25 Set liquibase schema name explicitly

### DIFF
--- a/src/main/java/org/folio/liquibase/LiquibaseUtil.java
+++ b/src/main/java/org/folio/liquibase/LiquibaseUtil.java
@@ -80,6 +80,7 @@ public class LiquibaseUtil {
   private static void runScripts(String schemaName, Connection connection, String changelogPath) throws LiquibaseException {
     Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(connection));
     database.setDefaultSchemaName(schemaName);
+    database.setLiquibaseSchemaName(schemaName);
     try (Liquibase liquibase = new Liquibase(changelogPath, new ClassLoaderResourceAccessor(), database)) {
       liquibase.update(new Contexts());
     }


### PR DESCRIPTION
DO NOT MERGE

Resolves [LIQUTIL-25](https://issues.folio.org/browse/LIQUTIL-25)

It looks like folio-liquibase-util sometimes uses wrong schema for liquibase's own tables.