### PR TITLE
LIQUTIL-26: Vert.x 4.3.3, PostgreSQL 42.5.0 fixing vulns; bump others

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,11 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.3.1</vertx.version>
-    <liquibase.version>4.9.0</liquibase.version>
-    <raml-module-builder.version>34.0.0</raml-module-builder.version>
-    <junit.version>4.13.1</junit.version>
-    <postgresql.version>42.3.3</postgresql.version>
+    <vertx.version>4.3.3</vertx.version>
+    <liquibase.version>4.15.0</liquibase.version>
+    <raml-module-builder.version>34.0.2</raml-module-builder.version>
+    <junit.version>4.13.2</junit.version>
+    <postgresql.version>42.5.0</postgresql.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Upgrade Vert.x from 4.3.1 to 4.3.3 fixing disabled SSL: https://github.com/vert-x3/wiki/wiki/4.3.2-Release-Notes#vertx-web

Upgrade postgresql JDBC driver from 42.3.3 to 42.5.0 fixing SQL Injection: https://nvd.nist.gov/vuln/detail/CVE-2022-31197

Upgrade RMB from 34.0.0 to 34.0.2 to match the new Vert.x version.

Upgrade liquibase from 4.9.0 to 4.15.0.

Upgrade JUnit from 4.13.1 to 4.13.2.