### PR TITLE
LIQUTIL-28: Liquibase 4.16.1 fixing snakeyaml vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vertx.version>4.3.3</vertx.version>
-    <liquibase.version>4.15.0</liquibase.version>
+    <liquibase.version>4.16.1</liquibase.version>
     <raml-module-builder.version>34.0.2</raml-module-builder.version>
     <junit.version>4.13.2</junit.version>
     <postgresql.version>42.5.0</postgresql.version>


### PR DESCRIPTION
Upgrade liquibase from 4.15.0 to 4.16.1.

This indirectly upgrades snakeyaml from 1.27 to 1.31 fixing Denial of Service (DoS) and Stack-based Buffer Overflow vulnerabilities: https://nvd.nist.gov/vuln/detail/CVE-2022-25857
https://nvd.nist.gov/vuln/detail/CVE-2022-38749
https://nvd.nist.gov/vuln/detail/CVE-2022-38751
https://nvd.nist.gov/vuln/detail/CVE-2022-38750
https://nvd.nist.gov/vuln/detail/CVE-2022-38752