### PR TITLE
LIQUTIL-32: commons-text 1.10.0 fixing Arbitrary Code Execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,16 @@
       <version>1.33</version>
     </dependency>
     <dependency>
+      <!-- Remove this commons-text dependency after upgrading to liquibase-core version
+           that has a commons-text dependency with version >= 1.10.0.
+           commons-text < 1.10.0 has Arbitrary Code Execution vulnerability:
+           https://nvd.nist.gov/vuln/detail/CVE-2022-42889
+      -->
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.10.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <version>${postgresql.version}</version>


### PR DESCRIPTION
Upgrade commons-text from 1.9 to 1.10.0 fixing Arbitrary Code Execution
https://nvd.nist.gov/vuln/detail/CVE-2022-42889