### PR TITLE
LIQUTIL-33: Upgrade RMB 35.0.1, Vert.x 4.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.3.3</vertx.version>
+    <vertx.version>4.3.4</vertx.version>
     <liquibase.version>4.16.1</liquibase.version>
-    <raml-module-builder.version>34.0.2</raml-module-builder.version>
+    <raml-module-builder.version>35.0.1</raml-module-builder.version>
     <junit.version>4.13.2</junit.version>
     <postgresql.version>42.5.0</postgresql.version>
   </properties>


### PR DESCRIPTION
Upgrade RMB from unsupported 34.0.2 to 35.0.1. This indirectly upgrades jackson-databind from 2.13.2.1 to 2.13.4.2 fixing Denial of Service (DoS) 
https://nvd.nist.gov/vuln/detail/CVE-2022-42004

Upgrade Vert.x from 4.3.3 to 4.3.4 to match the Vert.x version from RMB.