### PR TITLE
LIQUTIL-40: Upgrade to Liquibase 4.24.0, RMB 35.1.0, Vert.x 4.4.5, ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,11 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.3.7</vertx.version>
-    <liquibase.version>4.19.0</liquibase.version>
-    <raml-module-builder.version>35.0.4</raml-module-builder.version>
+    <vertx.version>4.4.5</vertx.version>
+    <liquibase.version>4.24.0</liquibase.version>
+    <raml-module-builder.version>35.1.0</raml-module-builder.version>
     <junit.version>4.13.2</junit.version>
-    <postgresql.version>42.5.1</postgresql.version>
+    <postgresql.version>42.6.0</postgresql.version>
   </properties>
 
   <dependencies>
@@ -87,7 +87,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M2</version>
+        <version>3.4.1</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -107,7 +107,7 @@
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <release>17</release>
           <compilerArgument>-Xlint:unchecked</compilerArgument>
@@ -117,7 +117,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
+        <version>3.1.2</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
@@ -126,7 +126,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.5.1</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -138,6 +138,7 @@
               <outputFile>
                 ${project.build.directory}/${project.artifactId}-fat.jar
               </outputFile>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>
@@ -153,7 +154,7 @@
 
       <plugin>  <!-- *-source.jar for https://repository.folio.org -->
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -167,7 +168,7 @@
 
       <plugin>  <!-- *-javadoc.jar for https://repository.folio.org -->
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -181,7 +182,7 @@
 
       <plugin>  <!-- Enforce that this deploy runs AFTER attach-sources and attach-javadocs -->
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M2</version>
+        <version>3.1.1</version>
         <executions>
           <execution>
             <id>deploy</id>
@@ -196,7 +197,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
+        <version>3.0.1</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>


### PR DESCRIPTION
Upgrade to latest stable versions for Poppy.

RMB upgrading notes for Poppy: https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md#version-351