### PR TITLE
LIQUTIL-41: Upgrade liquibase-util to RMB v35.2.0 and Vertx 4.5.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 1.8.0 2024-03-14
+* [LIQUTIL-41](https://issues.folio.org/browse/LIQUTIL-41) Upgrade RMB to v35.2.0
+
 ## 1.7.0 2023-10-11
 * [LIQUTIL-37](https://issues.folio.org/browse/LIQUTIL-37) Upgrade folio-liquibase-util to Java 17
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,11 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.4.5</vertx.version>
+    <vertx.version>4.5.4</vertx.version>
     <liquibase.version>4.24.0</liquibase.version>
-    <raml-module-builder.version>35.1.0</raml-module-builder.version>
+    <raml-module-builder.version>35.2.0</raml-module-builder.version>
     <junit.version>4.13.2</junit.version>
-    <postgresql.version>42.6.0</postgresql.version>
+    <postgresql.version>42.7.2</postgresql.version>
   </properties>
 
   <dependencies>
@@ -117,7 +117,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.2.5</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
@@ -126,7 +126,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.2</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -168,7 +168,7 @@
 
       <plugin>  <!-- *-javadoc.jar for https://repository.folio.org -->
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.3</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
## Purpose
Upgrade mod-source-record-manager to RMB 35.2.0 and Vertx 4.5.4

## Learning
[LIQUTIL-41](https://folio-org.atlassian.net/browse/LIQUTIL-41)