### PR TITLE
LIQUTIL-43 folio-liquibase-util Ramsons 2024 R2 - RMB v35.3.x update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 1.8.0 2024-03-19
 * [LIQUTIL-41](https://issues.folio.org/browse/LIQUTIL-41) Upgrade RMB to v35.2.0
+* [LIQUTIL-43](https://folio-org.atlassian.net/browse/LIQUTIL-43) folio-liquibase-util Ramsons 2024 R2 - RMB v35.3.x update
 
 ## 1.7.0 2023-10-11
 * [LIQUTIL-37](https://issues.folio.org/browse/LIQUTIL-37) Upgrade folio-liquibase-util to Java 17

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
       <artifactId>domain-models-runtime</artifactId>
       <version>${raml-module-builder.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.17.0</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.5.4</vertx.version>
+    <vertx.version>4.5.7</vertx.version>
     <liquibase.version>4.24.0</liquibase.version>
-    <raml-module-builder.version>35.2.0</raml-module-builder.version>
+    <raml-module-builder.version>35.3.0</raml-module-builder.version>
     <junit.version>4.13.2</junit.version>
     <postgresql.version>42.7.2</postgresql.version>
   </properties>

--- a/src/test/java/org/folio/rest/tools/utils/ModuleName.java
+++ b/src/test/java/org/folio/rest/tools/utils/ModuleName.java
@@ -3,9 +3,14 @@ package org.folio.rest.tools.utils;
 public class ModuleName {
 
   private static final String MODULE_NAME = "folio_liquibase_util";
+  private static final String MODULE_VERSION = "1.0.0"; // or the appropriate version
 
   public static String getModuleName() {
     return MODULE_NAME;
+  }
+
+  public static String getModuleVersion() {
+    return MODULE_VERSION;
   }
 
 }


### PR DESCRIPTION
### Purpose
[LIQUTIL-43](https://folio-org.atlassian.net/browse/LIQUTIL-43) folio-liquibase-util Ramsons 2024 R2 - RMB v35.3.x update

### Approach
Upgrade to RMB v35.3

Follow the [RMB upgrade notes for 35.3.x](https://github.com/folio-org/raml-module-builder/releases/tag/v35.3.0) upgrade.

Upgrade Vertx to 4.5.7 version.